### PR TITLE
feat: implement US11 - persist chat history and refactor for abstract…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -980,6 +980,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1783,7 +1784,8 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -3150,6 +3152,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3483,6 +3486,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -3772,6 +3776,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3798,6 +3803,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3895,6 +3901,7 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -1,15 +1,13 @@
-import { MessageLogService } from "../messages/message-log.service";
-import { MessageProcessorService } from "../messages/message-processor.service";
+import { IMessageLogService } from "../messages/message-log.interface";
+import { IMessageProcessor } from "../messages/message-processor.interface";
 import type { MessagingProvider, IncomingMessage } from "../types/messaging";
 
 export class ProconBot {
-  private logService: MessageLogService;
-  private processor: MessageProcessorService;
-
-  constructor(private provider: MessagingProvider) {
-    this.logService = new MessageLogService();
-    this.processor = new MessageProcessorService();
-  }
+  constructor(
+    private provider: MessagingProvider,
+    private processor: IMessageProcessor,
+    private logService: IMessageLogService
+  ) {}
 
   async start(): Promise<void> {
     await this.provider.initialize();
@@ -20,7 +18,7 @@ export class ProconBot {
   }
 
   private async handleIncomingMessage(message: IncomingMessage): Promise<void> {
-    this.logService.logIncomingMessage({
+    await this.logService.logIncomingMessage({
       from: message.from,
       body: message.body,
       timestamp: message.timestamp
@@ -30,6 +28,12 @@ export class ProconBot {
       message.from,
       message.body
     );
+
+    await this.logService.logOutgoingMessage({
+      from: message.from,
+      body: response,
+      timestamp: new Date().toISOString()
+    });
 
     await message.reply(response);
   }

--- a/src/database/repositories/mongo-history-repository.ts
+++ b/src/database/repositories/mongo-history-repository.ts
@@ -1,0 +1,26 @@
+import { ChatMessageModel } from "../models/chat-message.model";
+import { ChatMessage, IHistoryRepository } from "../../messages/history";
+
+export class MongoHistoryRepository implements IHistoryRepository {
+  async save(message: ChatMessage): Promise<void> {
+    await ChatMessageModel.create({
+      from: message.from,
+      direction: message.direction,
+      body: message.body,
+      clientTimestamp: message.timestamp
+    });
+  }
+
+  async findByUser(userId: string): Promise<ChatMessage[]> {
+    const records = await ChatMessageModel.find({ from: userId })
+      .sort({ createdAt: 1 })
+      .exec();
+
+    return records.map((record: any) => ({
+      from: record.from,
+      direction: record.direction as "in" | "out",
+      body: record.body,
+      timestamp: record.clientTimestamp
+    }));
+  }
+}

--- a/src/engine/flow-engine.interface.ts
+++ b/src/engine/flow-engine.interface.ts
@@ -1,0 +1,16 @@
+import {
+  FlowDefinition,
+  FlowSession,
+  FlowStep
+} from "../types/flow";
+import { FlowEngineResult } from "./flow-engine";
+
+export interface IFlowEngine {
+  start(flow: FlowDefinition): FlowSession;
+  getCurrentStep(flow: FlowDefinition, session: FlowSession): FlowStep | null;
+  answerCurrentStep(
+    flow: FlowDefinition,
+    session: FlowSession,
+    answer: string
+  ): FlowEngineResult;
+}

--- a/src/engine/flow-engine.ts
+++ b/src/engine/flow-engine.ts
@@ -5,6 +5,7 @@ import {
   FlowSession,
   FlowStep
 } from "../types/flow";
+import { IFlowEngine } from "./flow-engine.interface";
 
 export interface FlowEngineNextStepResult {
   type: "step";
@@ -21,7 +22,7 @@ export type FlowEngineResult =
   | FlowEngineNextStepResult
   | FlowEngineCompletedResult;
 
-export class FlowEngine {
+export class FlowEngine implements IFlowEngine {
   start(flow: FlowDefinition): FlowSession {
     return {
       flowId: flow.id,

--- a/src/flows/flow-matcher.interface.ts
+++ b/src/flows/flow-matcher.interface.ts
@@ -1,0 +1,5 @@
+import { FlowDefinition } from "../types/flow";
+
+export interface IFlowMatcher {
+  findByMessage(message: string, flows: FlowDefinition[]): FlowDefinition | null;
+}

--- a/src/flows/flow-matcher.ts
+++ b/src/flows/flow-matcher.ts
@@ -1,6 +1,7 @@
 import type { FlowDefinition } from "../types/flow";
+import { IFlowMatcher } from "./flow-matcher.interface";
 
-export class FlowMatcher {
+export class FlowMatcher implements IFlowMatcher {
   findByMessage(message: string, flows: FlowDefinition[]): FlowDefinition | null {
     const normalizedMessage = message.trim().toLowerCase();
 

--- a/src/messages/history.ts
+++ b/src/messages/history.ts
@@ -1,0 +1,12 @@
+export interface ChatMessage {
+  from: string;
+  body: string;
+  direction: "in" | "out";
+  /** Timestamp original do cliente ou sistema. */
+  timestamp: string;
+}
+
+export interface IHistoryRepository {
+  save(message: ChatMessage): Promise<void>;
+  findByUser(userId: string): Promise<ChatMessage[]>;
+}

--- a/src/messages/message-log.interface.ts
+++ b/src/messages/message-log.interface.ts
@@ -1,0 +1,14 @@
+export interface IncomingMessageLog {
+  from: string;
+  body: string;
+  timestamp: string;
+}
+
+export interface IMessageLogService {
+  logIncomingMessage(message: IncomingMessageLog): Promise<void>;
+  logOutgoingMessage(message: {
+    from: string;
+    body: string;
+    timestamp: string;
+  }): Promise<void>;
+}

--- a/src/messages/message-log.service.ts
+++ b/src/messages/message-log.service.ts
@@ -1,11 +1,30 @@
-export interface IncomingMessageLog {
-  from: string;
-  body: string;
-  timestamp: string;
-}
+import { IHistoryRepository } from "./history";
+import { IMessageLogService, IncomingMessageLog } from "./message-log.interface";
 
-export class MessageLogService {
-  logIncomingMessage(message: IncomingMessageLog): void {
+export class MessageLogService implements IMessageLogService {
+  constructor(private repository?: IHistoryRepository) {}
+
+  async logIncomingMessage(message: IncomingMessageLog): Promise<void> {
     console.log("[MESSAGE_LOG] Mensagem recebida:", message);
+    if (this.repository) {
+      await this.repository.save({
+        from: message.from,
+        body: message.body,
+        direction: "in",
+        timestamp: message.timestamp
+      });
+    }
   }
-}
+
+  async logOutgoingMessage(message: { from: string; body: string; timestamp: string }): Promise<void> {
+    console.log("[MESSAGE_LOG] Mensagem enviada:", message);
+    if (this.repository) {
+      await this.repository.save({
+        from: message.from,
+        body: message.body,
+        direction: "out",
+        timestamp: message.timestamp
+      });
+    }
+  }
+}

--- a/src/messages/message-processor.interface.ts
+++ b/src/messages/message-processor.interface.ts
@@ -1,0 +1,3 @@
+export interface IMessageProcessor {
+  processIncomingMessage(from: string, body: string): Promise<string>;
+}

--- a/src/messages/message-processor.service.ts
+++ b/src/messages/message-processor.service.ts
@@ -1,19 +1,16 @@
-import { FlowEngine } from "../engine/flow-engine";
-import { FlowMatcher } from "../flows/flow-matcher";
+import { IFlowEngine } from "../engine/flow-engine.interface";
+import { IFlowMatcher } from "../flows/flow-matcher.interface";
 import { flowRegistry } from "../flows/flow-registry";
-import { InMemorySessionStore } from "../sessions/in-memory-session-store";
+import { ISessionStore } from "../sessions/session-store.interface";
 import type { FlowOption, FlowResponse } from "../types/flow";
+import { IMessageProcessor } from "./message-processor.interface";
 
-export class MessageProcessorService {
-  private flowEngine: FlowEngine;
-  private flowMatcher: FlowMatcher;
-  private sessionStore: InMemorySessionStore;
-
-  constructor() {
-    this.flowEngine = new FlowEngine();
-    this.flowMatcher = new FlowMatcher();
-    this.sessionStore = new InMemorySessionStore();
-  }
+export class MessageProcessorService implements IMessageProcessor {
+  constructor(
+    private flowEngine: IFlowEngine,
+    private flowMatcher: IFlowMatcher,
+    private sessionStore: ISessionStore
+  ) {}
 
   async processIncomingMessage(from: string, body: string): Promise<string> {
     const existingSession = this.sessionStore.get(from);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,12 +2,23 @@ import "dotenv/config";
 
 import { ProconBot } from "./bot/bot";
 import { connectMongo, isMongoConfigured } from "./database/connection";
+import { MongoHistoryRepository } from "./database/repositories/mongo-history-repository";
+import { FlowEngine } from "./engine/flow-engine";
+import { FlowMatcher } from "./flows/flow-matcher";
+import { MessageLogService } from "./messages/message-log.service";
+import { MessageProcessorService } from "./messages/message-processor.service";
+import { InMemorySessionStore } from "./sessions/in-memory-session-store";
 import { WhatsAppProvider } from "./whatsapp/whatsapp-provider";
+
+import { IHistoryRepository } from "./messages/history";
 
 export async function bootstrap(): Promise<void> {
   try {
+    let historyRepository: IHistoryRepository | undefined;
+
     if (process.env.NODE_ENV !== "test" && isMongoConfigured()) {
       await connectMongo();
+      historyRepository = new MongoHistoryRepository();
     } else if (process.env.NODE_ENV !== "test" && !isMongoConfigured()) {
       console.warn(
         "MONGODB_URI não definido: persistência em MongoDB desabilitada. Defina a variável para ativar."
@@ -15,11 +26,25 @@ export async function bootstrap(): Promise<void> {
     }
 
     const provider = new WhatsAppProvider();
-    const bot = new ProconBot(provider);
+    const logService = new MessageLogService(historyRepository);
+
+    const flowEngine = new FlowEngine();
+    const flowMatcher = new FlowMatcher();
+    const sessionStore = new InMemorySessionStore();
+
+    const processor = new MessageProcessorService(
+      flowEngine,
+      flowMatcher,
+      sessionStore
+    );
+
+    const bot = new ProconBot(provider, processor, logService);
 
     await bot.start();
 
-    console.log("Servidor iniciado com arquitetura de provedores.");
+    console.log(
+      "Servidor iniciado com arquitetura de provedores e persistência."
+    );
   } catch (error) {
     console.error("Erro ao iniciar aplicação:", error);
     process.exit(1);

--- a/src/sessions/in-memory-session-store.ts
+++ b/src/sessions/in-memory-session-store.ts
@@ -1,4 +1,5 @@
 import type { FlowSession } from "../types/flow";
+import { ISessionStore } from "./session-store.interface";
 
 export interface UserFlowSession {
   userId: string;
@@ -6,7 +7,7 @@ export interface UserFlowSession {
   flowSession: FlowSession;
 }
 
-export class InMemorySessionStore {
+export class InMemorySessionStore implements ISessionStore {
   private sessions = new Map<string, UserFlowSession>();
 
   get(userId: string): UserFlowSession | null {

--- a/src/sessions/session-store.interface.ts
+++ b/src/sessions/session-store.interface.ts
@@ -1,0 +1,7 @@
+import { UserFlowSession } from "./in-memory-session-store";
+
+export interface ISessionStore {
+  get(userId: string): UserFlowSession | null;
+  save(session: UserFlowSession): void;
+  clear(userId: string): void;
+}

--- a/tests/bot/bot.test.ts
+++ b/tests/bot/bot.test.ts
@@ -1,35 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProconBot } from "../../src/bot/bot";
 
-const logIncomingMessageMock = vi.fn();
-const processIncomingMessageMock = vi.fn();
-
-vi.mock("../../src/messages/message-log.service", () => {
-  class MockMessageLogService {
-    logIncomingMessage = logIncomingMessageMock;
-  }
-  return { MessageLogService: MockMessageLogService };
-});
-
-vi.mock("../../src/messages/message-processor.service", () => {
-  class MockMessageProcessorService {
-    processIncomingMessage = processIncomingMessageMock.mockResolvedValue("Bot Response");
-  }
-  return { MessageProcessorService: MockMessageProcessorService };
-});
-
 describe("ProconBot", () => {
+  const mockProvider = {
+    initialize: vi.fn(),
+    onMessage: vi.fn()
+  };
+
+  const mockProcessor = {
+    processIncomingMessage: vi.fn().mockResolvedValue("Bot Response")
+  };
+
+  const mockLogService = {
+    logIncomingMessage: vi.fn().mockResolvedValue(undefined),
+    logOutgoingMessage: vi.fn().mockResolvedValue(undefined)
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("deve inicializar o provider e registrar handler de mensagem", async () => {
-    const mockProvider = {
-      initialize: vi.fn(),
-      onMessage: vi.fn()
-    };
-
-    const bot = new ProconBot(mockProvider as any);
+    const bot = new ProconBot(
+      mockProvider as any,
+      mockProcessor as any,
+      mockLogService as any
+    );
     await bot.start();
 
     expect(mockProvider.initialize).toHaveBeenCalledTimes(1);
@@ -38,12 +34,18 @@ describe("ProconBot", () => {
 
   it("deve processar mensagem e responder via reply do provider", async () => {
     let messageHandler: any;
-    const mockProvider = {
-      initialize: vi.fn(),
-      onMessage: vi.fn((handler) => { messageHandler = handler; })
+    const providerWithHandler = {
+      ...mockProvider,
+      onMessage: vi.fn((handler) => {
+        messageHandler = handler;
+      })
     };
 
-    const bot = new ProconBot(mockProvider as any);
+    const bot = new ProconBot(
+      providerWithHandler as any,
+      mockProcessor as any,
+      mockLogService as any
+    );
     await bot.start();
 
     const replyMock = vi.fn();
@@ -56,9 +58,13 @@ describe("ProconBot", () => {
 
     await messageHandler(mockMessage);
 
-    expect(logIncomingMessageMock).toHaveBeenCalledTimes(1);
-    expect(processIncomingMessageMock).toHaveBeenCalledTimes(1);
-    expect(processIncomingMessageMock).toHaveBeenCalledWith("user123", "ola");
+    expect(mockLogService.logIncomingMessage).toHaveBeenCalledTimes(1);
+    expect(mockProcessor.processIncomingMessage).toHaveBeenCalledTimes(1);
+    expect(mockProcessor.processIncomingMessage).toHaveBeenCalledWith(
+      "user123",
+      "ola"
+    );
+    expect(mockLogService.logOutgoingMessage).toHaveBeenCalledTimes(1);
     expect(replyMock).toHaveBeenCalledWith("Bot Response");
   });
 });

--- a/tests/database/mongo-history-repository.test.ts
+++ b/tests/database/mongo-history-repository.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MongoHistoryRepository } from "../../src/database/repositories/mongo-history-repository";
+import { ChatMessageModel } from "../../src/database/models/chat-message.model";
+
+vi.mock("../../src/database/models/chat-message.model", () => {
+  return {
+    ChatMessageModel: {
+      create: vi.fn(),
+      find: vi.fn().mockReturnThis(),
+      sort: vi.fn().mockReturnThis(),
+      exec: vi.fn()
+    }
+  };
+});
+
+describe("MongoHistoryRepository", () => {
+  const repository = new MongoHistoryRepository();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deve salvar uma mensagem no banco de dados", async () => {
+    const message = {
+      from: "user-123",
+      body: "Oi",
+      direction: "in" as const,
+      timestamp: "2024-01-01T10:00:00Z"
+    };
+
+    await repository.save(message);
+
+    expect(ChatMessageModel.create).toHaveBeenCalledWith({
+      from: "user-123",
+      direction: "in",
+      body: "Oi",
+      clientTimestamp: "2024-01-01T10:00:00Z"
+    });
+  });
+
+  it("deve recuperar mensagens de um usuário ordenadas por criação", async () => {
+    const mockData = [
+      { from: "user-1", body: "A", direction: "in", clientTimestamp: "T1" },
+      { from: "user-1", body: "B", direction: "out", clientTimestamp: "T2" }
+    ];
+
+    (ChatMessageModel as any).exec.mockResolvedValue(mockData);
+
+    const result = await repository.findByUser("user-1");
+
+    expect(ChatMessageModel.find).toHaveBeenCalledWith({ from: "user-1" });
+    expect((ChatMessageModel as any).sort).toHaveBeenCalledWith({ createdAt: 1 });
+    expect(result).toHaveLength(2);
+    expect(result[0].body).toBe("A");
+    expect(result[1].direction).toBe("out");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     globals: true,
-    environment: "node"
+    environment: "node",
+    exclude: ["node_modules", "dist"]
   }
 })


### PR DESCRIPTION
feat: implement US11 - persist chat history and refactor for abstraction

- Defined IHistoryRepository and implemented MongoHistoryRepository.
- Refactored MessageProcessor, ProconBot, and other services to use Dependency Injection.
- Successfully persisted incoming and outgoing messages for auditing.
- Updated all unit tests and verified 22/22 passing.
