### PR TITLE
feat: persist chat sessions in mongodb

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "dev": "tsx src/server.ts",
     "db:ping": "tsx src/database/scripts/ping.ts",
+    "db:inspect": "tsx src/database/scripts/inspect.ts",
     "db:seed-sample": "tsx src/database/scripts/seed-sample.ts",
     "rag:index": "tsx src/rag/build-index.ts"
   },

--- a/src/database/env.ts
+++ b/src/database/env.ts
@@ -3,8 +3,25 @@ export interface MongoEnv {
   dbName: string | undefined;
 }
 
+function readFirstDefinedEnv(names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name]?.trim();
+
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
 export function getMongoEnv(): MongoEnv {
-  const uri = process.env.MONGODB_URI?.trim() || undefined;
+  const uri = readFirstDefinedEnv([
+    "MONGODB_URI",
+    "MONGO_URL",
+    "MONGO_URI",
+    "Mongo_URL"
+  ]);
   const dbName = process.env.MONGODB_DB_NAME?.trim() || undefined;
 
   return { uri, dbName };

--- a/src/database/models/chat-session.model.ts
+++ b/src/database/models/chat-session.model.ts
@@ -13,7 +13,7 @@ const flowSessionSchema = new Schema(
 
 /**
  * Uma sessão de conversa ativa por usuário do canal (ex.: WhatsApp).
- * Alinhado a `UserFlowSession` em `in-memory-session-store.ts`.
+ * Alinhado a `UserFlowSession` em `src/sessions/user-flow-session.ts`.
  */
 const chatSessionSchema = new Schema(
   {

--- a/src/database/scripts/inspect.ts
+++ b/src/database/scripts/inspect.ts
@@ -1,0 +1,77 @@
+import "dotenv/config";
+
+import { ChatMessageModel } from "../models/chat-message.model";
+import { ChatSessionModel } from "../models/chat-session.model";
+import { connectMongo, disconnectMongo, isMongoConfigured } from "../connection";
+
+interface ChatSessionSummary {
+  userId: string;
+  flowId: string;
+  flowSession?: {
+    currentStepIndex?: number;
+    finished?: boolean;
+  };
+}
+
+interface ChatMessageSummary {
+  from: string;
+  direction: "in" | "out";
+  body: string;
+  clientTimestamp: string;
+}
+
+async function main(): Promise<void> {
+  if (!isMongoConfigured()) {
+    console.error(
+      "Defina MONGODB_URI, MONGO_URL ou equivalente no ambiente ou no arquivo .env."
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    await connectMongo();
+
+    const [sessionCount, messageCount, sampleSession, sampleMessage] = await Promise.all([
+      ChatSessionModel.countDocuments(),
+      ChatMessageModel.countDocuments(),
+      ChatSessionModel.findOne().sort({ updatedAt: -1 }).lean<ChatSessionSummary | null>(),
+      ChatMessageModel.findOne().sort({ createdAt: -1 }).lean<ChatMessageSummary | null>()
+    ]);
+
+    console.log("Mongo inspect OK.");
+    console.log(`chat_sessions: ${sessionCount}`);
+    console.log(`chat_messages: ${messageCount}`);
+
+    if (sampleSession) {
+      console.log(
+        "latest chat_session:",
+        JSON.stringify({
+          userId: sampleSession.userId,
+          flowId: sampleSession.flowId,
+          currentStepIndex: sampleSession.flowSession?.currentStepIndex,
+          finished: sampleSession.flowSession?.finished
+        })
+      );
+    }
+
+    if (sampleMessage) {
+      console.log(
+        "latest chat_message:",
+        JSON.stringify({
+          from: sampleMessage.from,
+          direction: sampleMessage.direction,
+          body: sampleMessage.body,
+          clientTimestamp: sampleMessage.clientTimestamp
+        })
+      );
+    }
+  } catch (error) {
+    console.error("Falha ao inspecionar MongoDB:", error);
+    process.exitCode = 1;
+  } finally {
+    await disconnectMongo();
+  }
+}
+
+void main();

--- a/src/messages/message-processor.service.ts
+++ b/src/messages/message-processor.service.ts
@@ -23,26 +23,26 @@ export class MessageProcessorService implements IMessageProcessor {
   ) {}
 
   async processIncomingMessage(from: string, body: string): Promise<string> {
-    const existingSession = this.sessionStore.get(from);
+    const existingSession = await this.sessionStore.get(from);
 
     // If user is in an active flow session, check for return-to-menu command first
     if (existingSession) {
       // Check if user wants to return to menu
       if (body.trim().toLowerCase() === "menu" || body.trim().toLowerCase() === "0") {
-        this.sessionStore.clear(from);
+        await this.sessionStore.clear(from);
         return getFlowsAsMenu(flowRegistry).menu;
       }
 
       // Pedido genérico de ajuda dentro de um fluxo → mostra menu e encerra sessão
       if (this.isHelpRequest(body)) {
-        this.sessionStore.clear(from);
+        await this.sessionStore.clear(from);
         return getFlowsAsMenu(flowRegistry).menu;
       }
 
       const flow = flowRegistry.find((item) => item.id === existingSession.flowId);
 
       if (!flow) {
-        this.sessionStore.clear(from);
+        await this.sessionStore.clear(from);
         return "Não consegui continuar seu atendimento. Vamos começar novamente.";
       }
 
@@ -53,11 +53,11 @@ export class MessageProcessorService implements IMessageProcessor {
       );
 
       if (result.type === "step") {
-        this.sessionStore.save(existingSession);
+        await this.sessionStore.save(existingSession);
         return this.formatStep(result.step.question, result.step.options);
       }
 
-      this.sessionStore.clear(from);
+      await this.sessionStore.clear(from);
       return this.formatCompletedResponse(result.response);
     }
 
@@ -85,7 +85,7 @@ export class MessageProcessorService implements IMessageProcessor {
       const matchedFlow = matchResult as FlowDefinition;
       const flowSession = this.flowEngine.start(matchedFlow);
 
-      this.sessionStore.save({
+      await this.sessionStore.save({
         userId: from,
         flowId: matchedFlow.id,
         flowSession
@@ -94,7 +94,7 @@ export class MessageProcessorService implements IMessageProcessor {
       const firstStep = this.flowEngine.getCurrentStep(matchedFlow, flowSession);
 
       if (!firstStep) {
-        this.sessionStore.clear(from);
+        await this.sessionStore.clear(from);
         return "Não foi possível iniciar o atendimento. Tente novamente.";
       }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,8 @@ import { MessageLogService } from "./messages/message-log.service";
 import { MessageProcessorService } from "./messages/message-processor.service";
 import { GeminiEmbeddingService, GeminiLlmService } from "./rag";
 import { InMemorySessionStore } from "./sessions/in-memory-session-store";
+import { MongoSessionStore } from "./sessions/mongo-session-store";
+import { ISessionStore } from "./sessions/session-store.interface";
 import { WhatsAppProvider } from "./whatsapp/whatsapp-provider";
 
 import { IHistoryRepository } from "./messages/history";
@@ -44,10 +46,19 @@ process.on("uncaughtException", (error) => {
 export async function bootstrap(): Promise<void> {
   try {
     let historyRepository: IHistoryRepository | undefined;
+    let sessionStore: ISessionStore = new InMemorySessionStore();
 
     if (process.env.NODE_ENV !== "test" && isMongoConfigured()) {
-      await connectMongo();
-      historyRepository = new MongoHistoryRepository();
+      try {
+        await connectMongo();
+        historyRepository = new MongoHistoryRepository();
+        sessionStore = new MongoSessionStore();
+      } catch (error) {
+        console.warn(
+          "Falha ao conectar no MongoDB: persistência em MongoDB desabilitada. Usando sessão em memória."
+        );
+        logFatalError("Conexao MongoDB", error);
+      }
     } else if (process.env.NODE_ENV !== "test" && !isMongoConfigured()) {
       console.warn(
         "MONGODB_URI não definido: persistência em MongoDB desabilitada. Defina a variável para ativar."
@@ -59,7 +70,6 @@ export async function bootstrap(): Promise<void> {
 
     const flowEngine = new FlowEngine();
     const flowMatcher = new FlowMatcher();
-    const sessionStore = new InMemorySessionStore();
 
     // RAG: usa busca semântica + LLM se GEMINI_API_KEY estiver configurada
     const geminiApiKey = process.env.GEMINI_API_KEY;

--- a/src/sessions/in-memory-session-store.ts
+++ b/src/sessions/in-memory-session-store.ts
@@ -1,24 +1,18 @@
-import type { FlowSession } from "../types/flow";
 import { ISessionStore } from "./session-store.interface";
-
-export interface UserFlowSession {
-  userId: string;
-  flowId: string;
-  flowSession: FlowSession;
-}
+import { UserFlowSession } from "./user-flow-session";
 
 export class InMemorySessionStore implements ISessionStore {
   private sessions = new Map<string, UserFlowSession>();
 
-  get(userId: string): UserFlowSession | null {
+  async get(userId: string): Promise<UserFlowSession | null> {
     return this.sessions.get(userId) ?? null;
   }
 
-  save(session: UserFlowSession): void {
+  async save(session: UserFlowSession): Promise<void> {
     this.sessions.set(session.userId, session);
   }
 
-  clear(userId: string): void {
+  async clear(userId: string): Promise<void> {
     this.sessions.delete(userId);
   }
 }

--- a/src/sessions/mongo-session-store.ts
+++ b/src/sessions/mongo-session-store.ts
@@ -1,0 +1,49 @@
+import { ChatSessionModel } from "../database/models/chat-session.model";
+import { ISessionStore } from "./session-store.interface";
+import { UserFlowSession } from "./user-flow-session";
+
+type ChatSessionDocument = {
+  userId: string;
+  flowId: string;
+  flowSession: UserFlowSession["flowSession"];
+};
+
+export class MongoSessionStore implements ISessionStore {
+  async get(userId: string): Promise<UserFlowSession | null> {
+    const session = await ChatSessionModel.findOne({ userId }).lean<ChatSessionDocument | null>();
+
+    if (!session) {
+      return null;
+    }
+
+    return this.toDomain(session);
+  }
+
+  async save(session: UserFlowSession): Promise<void> {
+    await ChatSessionModel.findOneAndUpdate(
+      { userId: session.userId },
+      {
+        userId: session.userId,
+        flowId: session.flowId,
+        flowSession: session.flowSession
+      },
+      {
+        upsert: true,
+        new: true,
+        setDefaultsOnInsert: true
+      }
+    );
+  }
+
+  async clear(userId: string): Promise<void> {
+    await ChatSessionModel.deleteOne({ userId });
+  }
+
+  private toDomain(session: ChatSessionDocument): UserFlowSession {
+    return {
+      userId: session.userId,
+      flowId: session.flowId,
+      flowSession: session.flowSession
+    };
+  }
+}

--- a/src/sessions/session-store.interface.ts
+++ b/src/sessions/session-store.interface.ts
@@ -1,7 +1,7 @@
-import { UserFlowSession } from "./in-memory-session-store";
+import { UserFlowSession } from "./user-flow-session";
 
 export interface ISessionStore {
-  get(userId: string): UserFlowSession | null;
-  save(session: UserFlowSession): void;
-  clear(userId: string): void;
+  get(userId: string): Promise<UserFlowSession | null>;
+  save(session: UserFlowSession): Promise<void>;
+  clear(userId: string): Promise<void>;
 }

--- a/src/sessions/user-flow-session.ts
+++ b/src/sessions/user-flow-session.ts
@@ -1,0 +1,7 @@
+import type { FlowSession } from "../types/flow";
+
+export interface UserFlowSession {
+  userId: string;
+  flowId: string;
+  flowSession: FlowSession;
+}

--- a/tests/database/env.test.ts
+++ b/tests/database/env.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getMongoEnv } from "../../src/database/env";
+
+const originalEnv = { ...process.env };
+
+describe("getMongoEnv", () => {
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("deve priorizar MONGODB_URI quando definida", () => {
+    process.env.MONGODB_URI = "mongodb://primary";
+    process.env.MONGO_URL = "mongodb://secondary";
+    process.env.MONGODB_DB_NAME = "proconbot";
+
+    expect(getMongoEnv()).toEqual({
+      uri: "mongodb://primary",
+      dbName: "proconbot"
+    });
+  });
+
+  it("deve aceitar MONGO_URL como fallback compatível com Railway", () => {
+    delete process.env.MONGODB_URI;
+    process.env.MONGO_URL = "mongodb://railway-internal";
+
+    expect(getMongoEnv()).toEqual({
+      uri: "mongodb://railway-internal",
+      dbName: undefined
+    });
+  });
+
+  it("deve aceitar Mongo_URL quando esse alias estiver disponível", () => {
+    delete process.env.MONGODB_URI;
+    delete process.env.MONGO_URL;
+    process.env.Mongo_URL = "mongodb://mixed-case";
+
+    expect(getMongoEnv()).toEqual({
+      uri: "mongodb://mixed-case",
+      dbName: undefined
+    });
+  });
+});

--- a/tests/messages/message-processor.test.ts
+++ b/tests/messages/message-processor.test.ts
@@ -5,6 +5,29 @@ import { FlowMatcher } from "../../src/flows/flow-matcher";
 import { KnowledgeService } from "../../src/knowledge/knowledge-service";
 import type { IKnowledgeRepository } from "../../src/knowledge/knowledge-repository.interface";
 import { InMemorySessionStore } from "../../src/sessions/in-memory-session-store";
+import type { ISessionStore } from "../../src/sessions/session-store.interface";
+import type { UserFlowSession } from "../../src/sessions/user-flow-session";
+
+class SpySessionStore implements ISessionStore {
+  private sessions = new Map<string, UserFlowSession>();
+
+  saveCalls = 0;
+  clearCalls = 0;
+
+  async get(userId: string): Promise<UserFlowSession | null> {
+    return this.sessions.get(userId) ?? null;
+  }
+
+  async save(session: UserFlowSession): Promise<void> {
+    this.saveCalls += 1;
+    this.sessions.set(session.userId, session);
+  }
+
+  async clear(userId: string): Promise<void> {
+    this.clearCalls += 1;
+    this.sessions.delete(userId);
+  }
+}
 
 describe("MessageProcessorService - Menu and Numeric Selection", () => {
   let processor: MessageProcessorService;
@@ -257,6 +280,83 @@ describe("MessageProcessorService - Menu and Numeric Selection", () => {
       const response = await processor.processIncomingMessage("user-reminder2", "xyz");
 
       expect(response).toContain("menu");
+    });
+  });
+
+  describe("PersistÃªncia de sessÃ£o", () => {
+    it("deve salvar a sessÃ£o ao iniciar um fluxo", async () => {
+      const sessionStore = new SpySessionStore();
+      const processorWithSpyStore = new MessageProcessorService(
+        new FlowEngine(),
+        new FlowMatcher(),
+        sessionStore,
+        new KnowledgeService(knowledgeRepositoryMock)
+      );
+
+      await processorWithSpyStore.processIncomingMessage("user-session-1", "1");
+
+      const savedSession = await sessionStore.get("user-session-1");
+      expect(sessionStore.saveCalls).toBe(1);
+      expect(savedSession).not.toBeNull();
+      expect(savedSession?.flowId).toBe("cobranca_indevida");
+      expect(savedSession?.flowSession.currentStepIndex).toBe(0);
+      expect(savedSession?.flowSession.answers).toEqual({});
+    });
+
+    it("deve recuperar e atualizar a sessÃ£o existente conforme o fluxo avanÃ§a", async () => {
+      const sessionStore = new SpySessionStore();
+      const processorWithSpyStore = new MessageProcessorService(
+        new FlowEngine(),
+        new FlowMatcher(),
+        sessionStore,
+        new KnowledgeService(knowledgeRepositoryMock)
+      );
+
+      await processorWithSpyStore.processIncomingMessage("user-session-2", "5");
+      await processorWithSpyStore.processIncomingMessage("user-session-2", "1");
+
+      const updatedSession = await sessionStore.get("user-session-2");
+      expect(sessionStore.saveCalls).toBe(2);
+      expect(updatedSession).not.toBeNull();
+      expect(updatedSession?.flowSession.currentStepIndex).toBe(1);
+      expect(updatedSession?.flowId).toBe("garantia_produto");
+      expect(updatedSession?.flowSession.answers).toMatchObject({
+        produto_com_defeito: "sim"
+      });
+    });
+
+    it("deve remover a sessÃ£o ao finalizar o atendimento", async () => {
+      const sessionStore = new SpySessionStore();
+      const processorWithSpyStore = new MessageProcessorService(
+        new FlowEngine(),
+        new FlowMatcher(),
+        sessionStore,
+        new KnowledgeService(knowledgeRepositoryMock)
+      );
+
+      await processorWithSpyStore.processIncomingMessage("user-session-3", "1");
+      await processorWithSpyStore.processIncomingMessage("user-session-3", "2");
+
+      const finishedSession = await sessionStore.get("user-session-3");
+      expect(sessionStore.clearCalls).toBe(1);
+      expect(finishedSession).toBeNull();
+    });
+
+    it("deve remover a sessÃ£o ao receber 'menu' durante o atendimento", async () => {
+      const sessionStore = new SpySessionStore();
+      const processorWithSpyStore = new MessageProcessorService(
+        new FlowEngine(),
+        new FlowMatcher(),
+        sessionStore,
+        new KnowledgeService(knowledgeRepositoryMock)
+      );
+
+      await processorWithSpyStore.processIncomingMessage("user-session-4", "1");
+      await processorWithSpyStore.processIncomingMessage("user-session-4", "menu");
+
+      const clearedSession = await sessionStore.get("user-session-4");
+      expect(sessionStore.clearCalls).toBe(1);
+      expect(clearedSession).toBeNull();
     });
   });
 });

--- a/tests/sessions/mongo-session-store.test.ts
+++ b/tests/sessions/mongo-session-store.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserFlowSession } from "../../src/sessions/user-flow-session";
+
+const modelMocks = vi.hoisted(() => ({
+  findOne: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+  deleteOne: vi.fn()
+}));
+
+vi.mock("../../src/database/models/chat-session.model", () => ({
+  ChatSessionModel: {
+    findOne: modelMocks.findOne,
+    findOneAndUpdate: modelMocks.findOneAndUpdate,
+    deleteOne: modelMocks.deleteOne
+  }
+}));
+
+import { MongoSessionStore } from "../../src/sessions/mongo-session-store";
+
+describe("MongoSessionStore", () => {
+  let store: MongoSessionStore;
+  const session: UserFlowSession = {
+    userId: "user-1",
+    flowId: "cobranca_indevida",
+    flowSession: {
+      flowId: "cobranca_indevida",
+      currentStepIndex: 1,
+      answers: {
+        reconhece_cobranca: "sim"
+      },
+      finished: false
+    }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new MongoSessionStore();
+  });
+
+  it("deve recuperar sessÃ£o existente do banco", async () => {
+    modelMocks.findOne.mockReturnValue({
+      lean: vi.fn().mockResolvedValue(session)
+    });
+
+    await expect(store.get("user-1")).resolves.toEqual(session);
+    expect(modelMocks.findOne).toHaveBeenCalledWith({ userId: "user-1" });
+  });
+
+  it("deve retornar null quando a sessÃ£o nÃ£o existe", async () => {
+    modelMocks.findOne.mockReturnValue({
+      lean: vi.fn().mockResolvedValue(null)
+    });
+
+    await expect(store.get("missing-user")).resolves.toBeNull();
+  });
+
+  it("deve salvar nova sessÃ£o com upsert", async () => {
+    modelMocks.findOneAndUpdate.mockResolvedValue(undefined);
+
+    await store.save(session);
+
+    expect(modelMocks.findOneAndUpdate).toHaveBeenCalledWith(
+      { userId: "user-1" },
+      {
+        userId: "user-1",
+        flowId: "cobranca_indevida",
+        flowSession: session.flowSession
+      },
+      {
+        upsert: true,
+        new: true,
+        setDefaultsOnInsert: true
+      }
+    );
+  });
+
+  it("deve sobrescrever a sessÃ£o existente do mesmo usuÃ¡rio", async () => {
+    modelMocks.findOneAndUpdate.mockResolvedValue(undefined);
+
+    await store.save({
+      ...session,
+      flowSession: {
+        ...session.flowSession,
+        currentStepIndex: 2,
+        answers: {
+          ...session.flowSession.answers,
+          prazo: "ate7"
+        }
+      }
+    });
+
+    expect(modelMocks.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(modelMocks.findOneAndUpdate.mock.calls[0][0]).toEqual({ userId: "user-1" });
+    expect(modelMocks.findOneAndUpdate.mock.calls[0][1]).toMatchObject({
+      flowSession: {
+        currentStepIndex: 2,
+        answers: {
+          reconhece_cobranca: "sim",
+          prazo: "ate7"
+        }
+      }
+    });
+  });
+
+  it("deve remover a sessÃ£o ao limpar o atendimento", async () => {
+    modelMocks.deleteOne.mockResolvedValue(undefined);
+
+    await store.clear("user-1");
+
+    expect(modelMocks.deleteOne).toHaveBeenCalledWith({ userId: "user-1" });
+  });
+});

--- a/tests/whatsapp/server.test.ts
+++ b/tests/whatsapp/server.test.ts
@@ -1,16 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { bootstrap } from "../../src/server";
 
-const startMock = vi.fn();
-const messageProcessorConstructorSpy = vi.fn();
-const markdownRepositoryConstructorSpy = vi.fn();
-const semanticRepositoryConstructorSpy = vi.fn();
-const semanticRepositoryInitializeSpy = vi.fn().mockResolvedValue(undefined);
-const knowledgeServiceConstructorSpy = vi.fn();
+const mocks = vi.hoisted(() => ({
+  startMock: vi.fn(),
+  messageProcessorConstructorSpy: vi.fn(),
+  connectMongoMock: vi.fn().mockResolvedValue(undefined),
+  isMongoConfiguredMock: vi.fn(),
+  markdownRepositoryConstructorSpy: vi.fn(),
+  semanticRepositoryConstructorSpy: vi.fn(),
+  semanticRepositoryInitializeSpy: vi.fn().mockResolvedValue(undefined),
+  knowledgeServiceConstructorSpy: vi.fn(),
+  inMemorySessionStoreConstructorSpy: vi.fn(),
+  mongoSessionStoreConstructorSpy: vi.fn()
+}));
+
+vi.mock("../../src/database/connection", () => ({
+  connectMongo: mocks.connectMongoMock,
+  isMongoConfigured: mocks.isMongoConfiguredMock
+}));
 
 vi.mock("../../src/bot/bot", () => {
   class MockProconBot {
-    start = startMock;
+    start = mocks.startMock;
   }
 
   return {
@@ -34,7 +45,7 @@ vi.mock("../../src/messages/message-processor.service", () => {
       sessionStore: unknown,
       knowledgeService: unknown
     ) {
-      messageProcessorConstructorSpy(flowEngine, flowMatcher, sessionStore, knowledgeService);
+      mocks.messageProcessorConstructorSpy(flowEngine, flowMatcher, sessionStore, knowledgeService);
     }
   }
 
@@ -46,20 +57,20 @@ vi.mock("../../src/messages/message-processor.service", () => {
 vi.mock("../../src/knowledge", () => {
   class MockMarkdownCdcRepository {
     constructor() {
-      markdownRepositoryConstructorSpy();
+      mocks.markdownRepositoryConstructorSpy();
     }
   }
 
   class MockSemanticCdcRepository {
     constructor(embeddingService: unknown) {
-      semanticRepositoryConstructorSpy(embeddingService);
+      mocks.semanticRepositoryConstructorSpy(embeddingService);
     }
-    initialize = semanticRepositoryInitializeSpy;
+    initialize = mocks.semanticRepositoryInitializeSpy;
   }
 
   class MockKnowledgeService {
     constructor(repository: unknown, llmService?: unknown) {
-      knowledgeServiceConstructorSpy(repository, llmService);
+      mocks.knowledgeServiceConstructorSpy(repository, llmService);
     }
   }
 
@@ -85,10 +96,35 @@ vi.mock("../../src/rag", () => {
   };
 });
 
+vi.mock("../../src/sessions/in-memory-session-store", () => {
+  class MockInMemorySessionStore {
+    constructor() {
+      mocks.inMemorySessionStoreConstructorSpy();
+    }
+  }
+
+  return {
+    InMemorySessionStore: MockInMemorySessionStore
+  };
+});
+
+vi.mock("../../src/sessions/mongo-session-store", () => {
+  class MockMongoSessionStore {
+    constructor() {
+      mocks.mongoSessionStoreConstructorSpy();
+    }
+  }
+
+  return {
+    MongoSessionStore: MockMongoSessionStore
+  };
+});
+
 describe("server bootstrap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.NODE_ENV = "test";
+    mocks.isMongoConfiguredMock.mockReturnValue(false);
   });
 
   it("deve inicializar o bot", async () => {
@@ -96,7 +132,7 @@ describe("server bootstrap", () => {
 
     await bootstrap();
 
-    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(mocks.startMock).toHaveBeenCalledTimes(1);
   });
 
   describe("sem GEMINI_API_KEY (fallback keyword)", () => {
@@ -107,12 +143,16 @@ describe("server bootstrap", () => {
     it("deve usar MarkdownCdcRepository e injetar no MessageProcessorService", async () => {
       await bootstrap();
 
-      expect(markdownRepositoryConstructorSpy).toHaveBeenCalledTimes(1);
-      expect(semanticRepositoryConstructorSpy).not.toHaveBeenCalled();
-      expect(knowledgeServiceConstructorSpy).toHaveBeenCalledTimes(1);
-      expect(messageProcessorConstructorSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.markdownRepositoryConstructorSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.semanticRepositoryConstructorSpy).not.toHaveBeenCalled();
+      expect(mocks.knowledgeServiceConstructorSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.messageProcessorConstructorSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.inMemorySessionStoreConstructorSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.mongoSessionStoreConstructorSpy).not.toHaveBeenCalled();
 
-      const knowledgeServiceArg = messageProcessorConstructorSpy.mock.calls[0][3];
+      const sessionStoreArg = mocks.messageProcessorConstructorSpy.mock.calls[0][2];
+      const knowledgeServiceArg = mocks.messageProcessorConstructorSpy.mock.calls[0][3];
+      expect(sessionStoreArg).toBeDefined();
       expect(knowledgeServiceArg).toBeDefined();
     });
   });
@@ -129,18 +169,28 @@ describe("server bootstrap", () => {
     it("deve usar SemanticCdcRepository e inicializar o RAG", async () => {
       await bootstrap();
 
-      expect(semanticRepositoryConstructorSpy).toHaveBeenCalledTimes(1);
-      expect(semanticRepositoryInitializeSpy).toHaveBeenCalledTimes(1);
-      expect(markdownRepositoryConstructorSpy).not.toHaveBeenCalled();
-      expect(knowledgeServiceConstructorSpy).toHaveBeenCalledTimes(1);
-      expect(messageProcessorConstructorSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.semanticRepositoryConstructorSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.semanticRepositoryInitializeSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.markdownRepositoryConstructorSpy).not.toHaveBeenCalled();
+      expect(mocks.knowledgeServiceConstructorSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.messageProcessorConstructorSpy).toHaveBeenCalledTimes(1);
     });
 
     it("deve passar LLM service ao KnowledgeService no modo RAG", async () => {
       await bootstrap();
 
-      const [_repository, llmService] = knowledgeServiceConstructorSpy.mock.calls[0];
+      const [_repository, llmService] = mocks.knowledgeServiceConstructorSpy.mock.calls[0];
       expect(llmService).toBeDefined();
     });
+  });
+
+  it("deve usar MongoSessionStore quando estiver fora de teste e o MongoDB conectar", async () => {
+    process.env.NODE_ENV = "production";
+    mocks.isMongoConfiguredMock.mockReturnValue(true);
+
+    await bootstrap();
+
+    expect(mocks.connectMongoMock).toHaveBeenCalledTimes(1);
+    expect(mocks.mongoSessionStoreConstructorSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
Implements US32 by persisting user chat sessions in MongoDB with fallback to in-memory storage.

## Changes
- extracts `UserFlowSession` into a shared session type
- makes `ISessionStore` asynchronous
- adds `MongoSessionStore`
- updates `MessageProcessorService` to load/save/clear sessions asynchronously
- selects Mongo-backed session storage in `server.ts` when Mongo is available
- adds Railway-compatible Mongo env alias support
- adds Mongo inspection script for validation
- expands automated test coverage for session persistence

## Validation
- npm.cmd run test:run
- npm.cmd run typecheck
- npm.cmd run build
- Mongo connection validated with `.env`
- session persistence validated against real Mongo
