### PR TITLE
fix whatsapp remote auth mongo session save

### DIFF
--- a/src/database/repositories/mongo-history-repository.ts
+++ b/src/database/repositories/mongo-history-repository.ts
@@ -6,7 +6,7 @@ export class MongoHistoryRepository implements IHistoryRepository {
     await ChatMessageModel.create({
       from: message.from,
       direction: message.direction,
-      body: message.body,
+      body: message.body.trim() || "[mensagem sem texto]",
       clientTimestamp: message.timestamp
     });
   }

--- a/src/whatsapp/mongo-whatsapp-store.ts
+++ b/src/whatsapp/mongo-whatsapp-store.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync } from "node:fs";
-import { basename } from "node:path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
 import { WhatsappSessionModel } from "../database/models/whatsapp-session.model";
 
 /**
@@ -20,8 +20,8 @@ export class MongoWhatsappStore {
    * (ex: "/app/.wwebjs_auth/RemoteAuth-proconbot-jacarei")
    */
   async save(options: { session: string }): Promise<void> {
-    const zipPath = `${options.session}.zip`;
     const sessionName = basename(options.session); // normaliza para só o nome
+    const zipPath = this.resolveZipPath(options.session, sessionName);
 
     let data: Buffer;
     try {
@@ -78,5 +78,14 @@ export class MongoWhatsappStore {
   async delete(options: { session: string }): Promise<void> {
     await WhatsappSessionModel.deleteOne({ session: options.session });
     console.log(`[WhatsappStore] Sessão "${options.session}" removida do MongoDB.`);
+  }
+
+  private resolveZipPath(session: string, sessionName: string): string {
+    const authPath = process.env.WHATSAPP_AUTH_PATH?.trim() || ".wwebjs_auth";
+    const candidates = Array.from(
+      new Set([`${session}.zip`, join(authPath, `${sessionName}.zip`)])
+    );
+
+    return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
   }
 }

--- a/tests/database/mongo-history-repository.test.ts
+++ b/tests/database/mongo-history-repository.test.ts
@@ -38,7 +38,25 @@ describe("MongoHistoryRepository", () => {
     });
   });
 
-  it("deve recuperar mensagens de um usuário ordenadas por criação", async () => {
+  it("deve salvar um marcador quando a mensagem nao tiver texto", async () => {
+    const message = {
+      from: "user-123",
+      body: "",
+      direction: "in" as const,
+      timestamp: "2024-01-01T10:00:00Z"
+    };
+
+    await repository.save(message);
+
+    expect(ChatMessageModel.create).toHaveBeenCalledWith({
+      from: "user-123",
+      direction: "in",
+      body: "[mensagem sem texto]",
+      clientTimestamp: "2024-01-01T10:00:00Z"
+    });
+  });
+
+  it("deve recuperar mensagens de um usuario ordenadas por criacao", async () => {
     const mockData = [
       { from: "user-1", body: "A", direction: "in", clientTimestamp: "T1" },
       { from: "user-1", body: "B", direction: "out", clientTimestamp: "T2" }

--- a/tests/whatsapp/mongo-whatsapp-store.test.ts
+++ b/tests/whatsapp/mongo-whatsapp-store.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WhatsappSessionModel } from "../../src/database/models/whatsapp-session.model";
+import { MongoWhatsappStore } from "../../src/whatsapp/mongo-whatsapp-store";
+
+vi.mock("../../src/database/models/whatsapp-session.model", () => ({
+  WhatsappSessionModel: {
+    findOneAndUpdate: vi.fn(),
+    exists: vi.fn(),
+    findOne: vi.fn(),
+    deleteOne: vi.fn()
+  }
+}));
+
+describe("MongoWhatsappStore", () => {
+  let tempDir: string;
+  const previousAuthPath = process.env.WHATSAPP_AUTH_PATH;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tempDir = mkdtempSync(join(tmpdir(), "wwebjs-auth-"));
+    process.env.WHATSAPP_AUTH_PATH = tempDir;
+  });
+
+  afterEach(() => {
+    process.env.WHATSAPP_AUTH_PATH = previousAuthPath;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("deve salvar sessao quando o RemoteAuth envia apenas o nome", async () => {
+    const data = Buffer.from("zip-da-sessao");
+    writeFileSync(join(tempDir, "RemoteAuth-proconbot-jacarei-v2.zip"), data);
+
+    await new MongoWhatsappStore().save({
+      session: "RemoteAuth-proconbot-jacarei-v2"
+    });
+
+    expect(WhatsappSessionModel.findOneAndUpdate).toHaveBeenCalledWith(
+      { session: "RemoteAuth-proconbot-jacarei-v2" },
+      { data, updatedAt: expect.any(Date) },
+      { upsert: true, new: true }
+    );
+  });
+});


### PR DESCRIPTION
## Resumo

- Corrige o `MongoWhatsappStore` para localizar o ZIP da sessão dentro de `WHATSAPP_AUTH_PATH` / `.wwebjs_auth`.
- Mantém compatibilidade com chamadas que passem caminho completo da sessão.
- Evita erro de validação ao persistir mensagens sem texto no histórico.

## Validação

- `npm.cmd run test:run -- tests/whatsapp/mongo-whatsapp-store.test.ts tests/database/mongo-history-repository.test.ts`