### PR TITLE
feat: US39 resolve perda de memoria da LLM

### DIFF
--- a/src/messages/conversation-context-store.ts
+++ b/src/messages/conversation-context-store.ts
@@ -1,0 +1,27 @@
+export interface ConversationContext {
+  readonly userId: string;
+  readonly lastUserMessage: string;
+  readonly updatedAt: Date;
+}
+
+export interface IConversationContextStore {
+  get(userId: string): Promise<ConversationContext | null>;
+  save(context: ConversationContext): Promise<void>;
+  clear(userId: string): Promise<void>;
+}
+
+export class InMemoryConversationContextStore implements IConversationContextStore {
+  private readonly contexts = new Map<string, ConversationContext>();
+
+  async get(userId: string): Promise<ConversationContext | null> {
+    return this.contexts.get(userId) ?? null;
+  }
+
+  async save(context: ConversationContext): Promise<void> {
+    this.contexts.set(context.userId, context);
+  }
+
+  async clear(userId: string): Promise<void> {
+    this.contexts.delete(userId);
+  }
+}

--- a/src/messages/message-processor.service.ts
+++ b/src/messages/message-processor.service.ts
@@ -9,6 +9,10 @@ import { KnowledgeService } from "../knowledge/knowledge-service";
 import { ISessionStore } from "../sessions/session-store.interface";
 import type { FlowDefinition, FlowOption, FlowResponse } from "../types/flow";
 import {
+  InMemoryConversationContextStore,
+  type IConversationContextStore
+} from "./conversation-context-store";
+import {
   type ConversationMessageContext,
   IMessageProcessor
 } from "./message-processor.interface";
@@ -53,7 +57,8 @@ export class MessageProcessorService implements IMessageProcessor {
     private sessionStore: ISessionStore,
     private knowledgeService?: KnowledgeService,
     private entityRepository?: IEntityExtractionRepository,
-    private agendamentoConversation?: AgendamentoConversationHandler
+    private agendamentoConversation?: AgendamentoConversationHandler,
+    private conversationContextStore: IConversationContextStore = new InMemoryConversationContextStore()
   ) {}
 
   async processIncomingMessage(
@@ -96,6 +101,7 @@ export class MessageProcessorService implements IMessageProcessor {
     if (existingSession) {
       if (body.trim().toLowerCase() === "menu" || body.trim().toLowerCase() === "0") {
         await this.sessionStore.clear(from);
+        await this.conversationContextStore.clear(from);
         return {
           text: getFlowsAsMenu(flowRegistry).menu,
           nlpClassification: null,
@@ -105,6 +111,7 @@ export class MessageProcessorService implements IMessageProcessor {
 
       if (this.isHelpRequest(body)) {
         await this.sessionStore.clear(from);
+        await this.conversationContextStore.clear(from);
         return {
           text: getFlowsAsMenu(flowRegistry).menu,
           nlpClassification: null,
@@ -171,6 +178,7 @@ export class MessageProcessorService implements IMessageProcessor {
       }
 
       if (matchResult.type === "return_to_menu") {
+        await this.conversationContextStore.clear(from);
         return {
           text: getFlowsAsMenu(flowRegistry).menu,
           nlpClassification,
@@ -207,9 +215,16 @@ export class MessageProcessorService implements IMessageProcessor {
       };
     }
 
-    const knowledgeAnswer = await this.knowledgeService?.findAnswer(body);
+    const knowledgeQuery = await this.buildKnowledgeQuery(from, body);
+    const knowledgeAnswer = await this.knowledgeService?.findAnswer(knowledgeQuery);
 
     if (knowledgeAnswer) {
+      await this.conversationContextStore.save({
+        userId: from,
+        lastUserMessage: body,
+        updatedAt: new Date()
+      });
+
       const schedulingOffer =
         (await this.agendamentoConversation?.offerScheduling?.(from)) ?? "";
 
@@ -280,6 +295,71 @@ export class MessageProcessorService implements IMessageProcessor {
       .replace(/[^a-z\s]/g, "")
       .replace(/\s+/g, " ")
       .trim();
+  }
+
+  private async buildKnowledgeQuery(userId: string, body: string): Promise<string> {
+    const context = await this.conversationContextStore.get(userId);
+
+    if (!context || !this.isFollowUpQuestion(body)) {
+      return body;
+    }
+
+    return [
+      `Contexto anterior do consumidor: ${context.lastUserMessage}`,
+      `Pergunta atual do consumidor: ${body}`
+    ].join("\n");
+  }
+
+  private isFollowUpQuestion(body: string): boolean {
+    const normalized = this.normalizeNavigationText(body);
+
+    if (!normalized) {
+      return false;
+    }
+
+    const words = normalized.split(/\s+/).filter((w) => w.length > 0);
+
+    if (words.length <= 2) {
+      return false;
+    }
+
+    const followUpPatterns = [
+      "e agora",
+      "o que faco",
+      "que faco",
+      "como proceder",
+      "entrei em contato",
+      "nao quer",
+      "nao resolveu",
+      "nao resolver",
+      "se recusou",
+      "continua",
+      "mesmo assim"
+    ];
+
+    if (followUpPatterns.some((pattern) => normalized.includes(pattern))) {
+      return true;
+    }
+
+    const referenceTerms = new Set([
+      "ele",
+      "ela",
+      "eles",
+      "elas",
+      "isso",
+      "esse",
+      "essa",
+      "dessa",
+      "desse",
+      "fornecedor",
+      "loja",
+      "empresa",
+      "vendedor",
+      "resolver",
+      "resolvido"
+    ]);
+
+    return words.some((word) => referenceTerms.has(word));
   }
 
   private formatStep(question: string, options?: FlowOption[]): string {

--- a/tests/messages/message-processor.test.ts
+++ b/tests/messages/message-processor.test.ts
@@ -299,6 +299,48 @@ describe("MessageProcessorService - Menu and Numeric Selection", () => {
       expect(response).toContain("2. Nao");
       expect(response).toContain("menu");
     });
+
+    it("deve usar contexto anterior em pergunta livre de continuidade", async () => {
+      const queries: string[] = [];
+      const fm = new FlowMatcher(flowRegistry);
+      await fm.initialize();
+      const processorWithContext = new MessageProcessorService(
+        new FlowEngine(),
+        fm,
+        new InMemorySessionStore(),
+        new KnowledgeService({
+          search: async (query) => {
+            queries.push(query);
+            return [
+              {
+                score: 2,
+                entry: {
+                  id: "cdc-18",
+                  title: "Art. 18 - Produto com defeito",
+                  body: "Fornecedor responde por vicio de qualidade."
+                }
+              }
+            ];
+          }
+        })
+      );
+
+      await processorWithContext.processIncomingMessage(
+        "user-cdc-context",
+        "Comprei um brinquedo online e veio com defeito"
+      );
+      await processorWithContext.processIncomingMessage(
+        "user-cdc-context",
+        "Entrei em contato com o fornecedor e ele nao quer resolver, o que eu faco?"
+      );
+
+      expect(queries[1]).toContain(
+        "Contexto anterior do consumidor: Comprei um brinquedo online e veio com defeito"
+      );
+      expect(queries[1]).toContain(
+        "Pergunta atual do consumidor: Entrei em contato com o fornecedor"
+      );
+    });
   });
 
   describe("Help Request - 'me ajuda' e similares", () => {


### PR DESCRIPTION
  ## O que foi feito

  Resolvida a perda de contexto em perguntas livres respondidas pela base CDC/RAG.

  Antes, quando o usuário fazia uma pergunta inicial, por exemplo “comprei um brinquedo online e veio com defeito”, o bot respondia corretamente. Porém, se
  a próxima mensagem fosse uma continuação como “entrei em contato com o fornecedor e ele não quer resolver”, essa nova mensagem era tratada de forma
  isolada, sem considerar o assunto anterior.

  Nesta alteração foi adicionada uma memória curta de contexto para respostas da base de conhecimento. Quando o bot identifica uma pergunta de continuidade,
  ele envia para a consulta CDC/RAG a pergunta atual junto com o contexto anterior do consumidor.

  Também foi adicionada limpeza desse contexto quando o usuário volta ao menu.

  ## Arquivos alterados

  - `src/messages/conversation-context-store.ts`
  - `src/messages/message-processor.service.ts`
  - `tests/messages/message-processor.test.ts`

  ## Validação

  Executado com sucesso:

  - `npm.cmd run typecheck`
  - `npm.cmd run build`
  - `npm.cmd run test:run -- tests/messages/message-processor.test.ts tests/extraction/message-processor-rag-low-confidence.test.ts

Closes #79 