### PR TITLE
feat: usar temas semânticos no gráfico de assuntos

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -24,7 +24,7 @@ import {
 } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
 import { useMainLayoutOutlet } from '../hooks/useMainLayoutOutlet'
-import { api } from '../services/api'
+import { api, type TopicKpiItem } from '../services/api'
 
 type MetricId = 'conversas' | 'usuarios' | 'mensagens' | 'agendamentos' | 'atualizacao'
 
@@ -141,22 +141,6 @@ function normalizeStatus(status: unknown): string {
   return isNonEmptyString(status) ? status.trim().toLowerCase() : ''
 }
 
-function getAppointmentTopic(appointment: ApiAppointment): string {
-  if (
-    appointment.servico_id &&
-    typeof appointment.servico_id === 'object' &&
-    isNonEmptyString(appointment.servico_id.nome)
-  ) {
-    return appointment.servico_id.nome.trim()
-  }
-
-  if (isNonEmptyString(appointment.assunto)) {
-    return appointment.assunto.trim()
-  }
-
-  return 'Geral'
-}
-
 function getConversationId(conversation: ApiConversation): string | null {
   if (isNonEmptyString(conversation.id)) return conversation.id.trim()
   if (isNonEmptyString(conversation.identificador)) return conversation.identificador.trim()
@@ -260,6 +244,7 @@ export function DashboardPage() {
   const [error, setError] = useState<string | null>(null)
   const [appointments, setAppointments] = useState<ApiAppointment[]>([])
   const [conversations, setConversations] = useState<ApiConversation[]>([])
+  const [topics, setTopics] = useState<TopicKpiItem[]>([])
   const [kpiData, setKpiData] = useState<DashboardKpi>(() => createEmptyKpi())
   const [refreshRequest, setRefreshRequest] = useState(0)
   const [referenceDate, setReferenceDate] = useState(() => new Date())
@@ -290,13 +275,15 @@ export function DashboardPage() {
         }
         setError(null)
 
-        const [agendaRes, conversasRes] = await Promise.all([
+        const [agendaRes, conversasRes, assuntosRes] = await Promise.all([
           api.getAgenda(validToken),
           api.getConversas(validToken),
+          api.getAssuntosDashboard(validToken),
         ])
 
         const agenda = Array.isArray(agendaRes.dados) ? agendaRes.dados : []
         const conversas = Array.isArray(conversasRes.dados) ? conversasRes.dados : []
+        const assuntos = Array.isArray(assuntosRes.dados) ? assuntosRes.dados : []
         const conversationIds = uniqueValues(conversas.map(getConversationId))
         const kpiBatches = chunkKpiUserIds(conversationIds)
 
@@ -308,6 +295,7 @@ export function DashboardPage() {
 
         setAppointments(agenda)
         setConversations(conversas)
+        setTopics(assuntos)
         setKpiData(mergeKpis(kpiResults))
         setReferenceDate(new Date())
       } catch (err) {
@@ -398,16 +386,13 @@ export function DashboardPage() {
   }, [appointments, last7Days])
 
   const assuntosDonut = useMemo(() => {
-    const counts = appointments.reduce<Record<string, number>>((acc, appointment) => {
-      const topic = getAppointmentTopic(appointment)
-      acc[topic] = (acc[topic] ?? 0) + 1
-      return acc
-    }, {})
-
-    const entries = Object.entries(counts).sort((a, b) => b[1] - a[1])
+    const entries = topics
+      .map((topic) => [topic.name, Number(topic.value) || 0] as [string, number])
+      .filter(([, count]) => count > 0)
+      .sort((a, b) => b[1] - a[1])
 
     if (entries.length === 0) {
-      return [{ name: 'Sem agendamentos', value: 100, color: '#9CA3AF' }]
+      return [{ name: 'Sem dados', value: 100, color: '#9CA3AF' }]
     }
 
     const visibleEntries = entries.slice(0, 4)
@@ -421,7 +406,7 @@ export function DashboardPage() {
       value: Math.round((count / total) * 100),
       color: TOPIC_COLORS[index % TOPIC_COLORS.length],
     }))
-  }, [appointments])
+  }, [topics])
 
   const metrics = useMemo<DashboardMetric[]>(() => {
     const now = new Date()

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -32,6 +32,12 @@ export type HorarioDisponivel = {
   status: string
 }
 
+export type TopicKpiItem = {
+  flowId: string
+  name: string
+  value: number
+}
+
 async function request<T>(
   path: string,
   options: RequestInit = {},
@@ -121,6 +127,10 @@ export const api = {
   async getKpiDashboard(token: string, userIds: string[]) {
     const query = userIds.length > 0 ? `?users=${encodeURIComponent(userIds.join(','))}` : ''
     return request<any>(`/api/kpi/dashboard${query}`, {}, token)
+  },
+
+  async getAssuntosDashboard(token: string) {
+    return request<{ dados: TopicKpiItem[] }>('/api/kpi/assuntos', {}, token)
   },
 
   async criarFuncionario(

--- a/src/api/routes/kpi.routes.ts
+++ b/src/api/routes/kpi.routes.ts
@@ -2,6 +2,7 @@ import { Router, type NextFunction, type Request, type Response } from "express"
 import jwt from "jsonwebtoken";
 import { ZodError } from "zod";
 import { GetDashboardUseCase } from "../../application/use-cases/GetDashboardUseCase";
+import { GetTopicKpiUseCase } from "../../application/use-cases/GetTopicKpiUseCase";
 import { IHistoryRepository } from "../../messages/history";
 import { parseUserIds } from "../validation/dashboard.schema";
 
@@ -77,6 +78,26 @@ export function createKpiRouter(historyRepository: IHistoryRepository): Router {
           return;
         }
 
+        next(err);
+      }
+    }
+  );
+
+  /**
+   * GET /api/kpi/assuntos
+   * Retorna os principais temas classificados pelo chatbot.
+   * Requer Authorization: Bearer <token>
+   */
+  router.get(
+    "/assuntos",
+    authMiddleware,
+    async (_req: Request, res: Response, next: NextFunction) => {
+      try {
+        const useCase = new GetTopicKpiUseCase();
+        const result = await useCase.execute();
+
+        res.json({ dados: result });
+      } catch (err) {
         next(err);
       }
     }

--- a/src/api/utils/flowLabelHelper.ts
+++ b/src/api/utils/flowLabelHelper.ts
@@ -1,0 +1,27 @@
+const FLOW_LABELS: Record<string, string> = {
+  cobranca_indevida: "Cobrança indevida",
+  garantia_produto: "Garantia de produto",
+  cancelamento_plano: "Cancelamento de plano",
+  direito_arrependimento: "Direito de arrependimento",
+  emprestimo_nao_reconhecido: "Empréstimo não reconhecido",
+  agendamento: "Agendamento"
+};
+
+export function getFlowLabel(flowId: string): string {
+  const normalized = flowId.trim();
+
+  if (!normalized) {
+    return "Outros";
+  }
+
+  const knownLabel = FLOW_LABELS[normalized];
+  if (knownLabel) {
+    return knownLabel;
+  }
+
+  return normalized
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^./, (first) => first.toUpperCase());
+}

--- a/src/application/use-cases/GetTopicKpiUseCase.ts
+++ b/src/application/use-cases/GetTopicKpiUseCase.ts
@@ -1,0 +1,31 @@
+import { ConversationExtractionLogModel } from "../../database/models/conversation-extraction-log.model";
+import { getFlowLabel } from "../../api/utils/flowLabelHelper";
+
+export interface TopicKpiItem {
+  flowId: string;
+  name: string;
+  value: number;
+}
+
+interface TopicAggregationResult {
+  _id: string;
+  count: number;
+}
+
+export class GetTopicKpiUseCase {
+  async execute(limit = 10): Promise<TopicKpiItem[]> {
+    const rows = (await ConversationExtractionLogModel.aggregate([
+      { $match: { flowId: { $exists: true, $nin: [null, ""] } } },
+      { $group: { _id: { sessionId: "$sessionId", flowId: "$flowId" } } },
+      { $group: { _id: "$_id.flowId", count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: limit }
+    ])) as TopicAggregationResult[];
+
+    return rows.map((row) => ({
+      flowId: row._id,
+      name: getFlowLabel(row._id),
+      value: row.count
+    }));
+  }
+}

--- a/tests/api/flow-label-helper.test.ts
+++ b/tests/api/flow-label-helper.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getFlowLabel } from "../../src/api/utils/flowLabelHelper";
+
+describe("getFlowLabel", () => {
+  it("retorna label amigavel para fluxos conhecidos", () => {
+    expect(getFlowLabel("cobranca_indevida")).toBe("Cobrança indevida");
+    expect(getFlowLabel("garantia_produto")).toBe("Garantia de produto");
+    expect(getFlowLabel("cancelamento_plano")).toBe("Cancelamento de plano");
+    expect(getFlowLabel("direito_arrependimento")).toBe("Direito de arrependimento");
+    expect(getFlowLabel("emprestimo_nao_reconhecido")).toBe("Empréstimo não reconhecido");
+    expect(getFlowLabel("agendamento")).toBe("Agendamento");
+  });
+
+  it("formata flowId desconhecido como fallback legivel", () => {
+    expect(getFlowLabel("novo_fluxo-teste")).toBe("Novo fluxo teste");
+  });
+
+  it("usa Outros para flowId vazio", () => {
+    expect(getFlowLabel("   ")).toBe("Outros");
+  });
+});

--- a/tests/application/get-topic-kpi-use-case.test.ts
+++ b/tests/application/get-topic-kpi-use-case.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GetTopicKpiUseCase } from "../../src/application/use-cases/GetTopicKpiUseCase";
+import { ConversationExtractionLogModel } from "../../src/database/models/conversation-extraction-log.model";
+
+vi.mock("../../src/database/models/conversation-extraction-log.model", () => ({
+  ConversationExtractionLogModel: {
+    aggregate: vi.fn()
+  }
+}));
+
+describe("GetTopicKpiUseCase", () => {
+  const useCase = new GetTopicKpiUseCase();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("agrega assuntos por flowId contando uma vez por sessionId e flowId", async () => {
+    vi.mocked(ConversationExtractionLogModel.aggregate).mockResolvedValue([
+      { _id: "cobranca_indevida", count: 3 },
+      { _id: "garantia_produto", count: 2 },
+      { _id: "novo_fluxo", count: 1 }
+    ]);
+
+    const result = await useCase.execute();
+
+    expect(ConversationExtractionLogModel.aggregate).toHaveBeenCalledWith([
+      { $match: { flowId: { $exists: true, $nin: [null, ""] } } },
+      { $group: { _id: { sessionId: "$sessionId", flowId: "$flowId" } } },
+      { $group: { _id: "$_id.flowId", count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: 10 }
+    ]);
+    expect(result).toEqual([
+      { flowId: "cobranca_indevida", name: "Cobrança indevida", value: 3 },
+      { flowId: "garantia_produto", name: "Garantia de produto", value: 2 },
+      { flowId: "novo_fluxo", name: "Novo fluxo", value: 1 }
+    ]);
+  });
+
+  it("respeita limite customizado na agregacao", async () => {
+    vi.mocked(ConversationExtractionLogModel.aggregate).mockResolvedValue([]);
+
+    await useCase.execute(5);
+
+    expect(ConversationExtractionLogModel.aggregate).toHaveBeenCalledWith(
+      expect.arrayContaining([{ $limit: 5 }])
+    );
+  });
+});


### PR DESCRIPTION
  - adiciona KPI /api/kpi/assuntos baseado em conversation_extraction_logs
  - agrega assuntos por flowId contando uma vez por sessionId + flowId
  - adiciona labels amigáveis para os fluxos do chatbot
  - atualiza o Dashboard para alimentar Assuntos mais buscados pela nova API
  - mantém os gráficos de atendimentos e agendamentos usando dados de agenda
  - adiciona testes para labels e agregação do KPI de assuntos