### PR TITLE
feat: adiciona aviso de uso de IA no chatbot

### DIFF
--- a/src/messages/conversation-context-store.ts
+++ b/src/messages/conversation-context-store.ts
@@ -1,6 +1,7 @@
 export interface ConversationContext {
   readonly userId: string;
   readonly lastUserMessage: string;
+  readonly aiNoticeShown?: boolean;
   readonly updatedAt: Date;
 }
 

--- a/src/messages/message-processor.service.ts
+++ b/src/messages/message-processor.service.ts
@@ -21,6 +21,10 @@ import {
 const MENU_REMINDER =
   "\n\n_Digite *menu* a qualquer momento para voltar ao menu principal._";
 
+const AI_USAGE_NOTICE =
+  "Aviso: este atendimento utiliza inteligência artificial para auxiliar nas respostas. " +
+  "As orientações são informativas e não substituem o atendimento oficial do PROCON.";
+
 /** Termos que indicam pedido de ajuda/navegação (sem consulta jurídica). */
 const HELP_TERMS = new Set([
   "ajuda",
@@ -71,6 +75,7 @@ export class MessageProcessorService implements IMessageProcessor {
       from,
       body
     );
+    const responseText = await this.addAiUsageNoticeIfNeeded(from, text);
 
     await this.maybePersistExtraction(
       from,
@@ -81,7 +86,7 @@ export class MessageProcessorService implements IMessageProcessor {
       context?.sessionId
     );
 
-    return text;
+    return responseText;
   }
 
   private async dispatchMessage(from: string, body: string): Promise<DispatchOutcome> {
@@ -219,9 +224,11 @@ export class MessageProcessorService implements IMessageProcessor {
     const knowledgeAnswer = await this.knowledgeService?.findAnswer(knowledgeQuery);
 
     if (knowledgeAnswer) {
+      const currentContext = await this.conversationContextStore.get(from);
       await this.conversationContextStore.save({
         userId: from,
         lastUserMessage: body,
+        aiNoticeShown: currentContext?.aiNoticeShown,
         updatedAt: new Date()
       });
 
@@ -262,6 +269,26 @@ export class MessageProcessorService implements IMessageProcessor {
       nlpClassification,
       flowId
     });
+  }
+
+  private async addAiUsageNoticeIfNeeded(
+    userId: string,
+    text: string
+  ): Promise<string> {
+    const context = await this.conversationContextStore.get(userId);
+
+    if (context?.aiNoticeShown) {
+      return text;
+    }
+
+    await this.conversationContextStore.save({
+      userId,
+      lastUserMessage: context?.lastUserMessage ?? "",
+      aiNoticeShown: true,
+      updatedAt: new Date()
+    });
+
+    return `${AI_USAGE_NOTICE}\n\n${text}`;
   }
 
   private isHelpRequest(body: string): boolean {

--- a/tests/messages/message-processor.test.ts
+++ b/tests/messages/message-processor.test.ts
@@ -51,6 +51,13 @@ describe("MessageProcessorService - Menu and Numeric Selection", () => {
 
 
   describe("First Message - Menu Display", () => {
+    it("deve informar uso de IA na primeira resposta da conversa", async () => {
+      const response = await processor.processIncomingMessage("user-ai-notice-1", "oi");
+
+      expect(response).toContain("inteligência artificial");
+      expect(response).toContain("não substituem o atendimento oficial do PROCON");
+    });
+
     it("deve mostrar o menu quando primeira mensagem e saudacao ('oi')", async () => {
       const response = await processor.processIncomingMessage("user1", "oi");
 
@@ -83,6 +90,8 @@ describe("MessageProcessorService - Menu and Numeric Selection", () => {
       const response = await processor.processIncomingMessage("user2", "xyz123");
 
       expect(response).toContain("Não entendi sua mensagem");
+      expect(response).toContain("inteligência artificial");
+      expect(response).toContain("atendimento oficial do PROCON");
       expect(response).toContain("menu");
     });
 
@@ -104,6 +113,16 @@ describe("MessageProcessorService - Menu and Numeric Selection", () => {
       expect(response).toContain("Você reconhece ou contratou essa cobrança?");
       expect(response).toContain("1.");
       expect(response).toContain("2.");
+    });
+
+    it("nao deve repetir aviso de IA nas interacoes seguintes da mesma conversa", async () => {
+      const user = "user-ai-notice-2";
+
+      const firstResponse = await processor.processIncomingMessage(user, "1");
+      const secondResponse = await processor.processIncomingMessage(user, "1");
+
+      expect(firstResponse).toContain("inteligência artificial");
+      expect(secondResponse).not.toContain("inteligência artificial");
     });
 
     it("deve iniciar fluxo correto para cada número (1-5)", async () => {


### PR DESCRIPTION
Implementa a US25 adicionando um aviso claro na conversa informando que o atendimento utiliza inteligência artificial para auxiliar nas respostas.

  O que foi alterado:

- Adicionado aviso padrão no MessageProcessorService.
- O aviso informa que:
    - o sistema utiliza inteligência artificial;
    - as respostas têm caráter informativo;
    - as orientações não substituem atendimento oficial do PROCON.

- O aviso é exibido na primeira resposta da conversa.
- Foi adicionado controle aiNoticeShown no contexto da conversa para evitar repetição nas mensagens seguintes.
- O aviso também aparece quando a primeira mensagem cai no fallback de não entendimento.
- Foram adicionados testes cobrindo:
    - exibição do aviso na primeira resposta;
    - presença do aviso no fallback inicial;
    - não repetição do aviso nas interações seguintes da mesma conversa.
      
Closes #32 